### PR TITLE
Fixed the "index out of range" error when scanning for conflicting MAC commands.

### DIFF
--- a/internal/downlink/data/data.go
+++ b/internal/downlink/data/data.go
@@ -440,11 +440,9 @@ func setMACCommands(funcs ...func(*dataContext) error) func(*dataContext) error 
 
 			if seen {
 				for _, conflictingCID := range mapping.IncompatibleCIDs {
-					var deleted int
-					for i := range ctx.MACCommands {
-						j := i - deleted
-						if ctx.MACCommands[j].CID == conflictingCID {
-							ctx.MACCommands = append(ctx.MACCommands[:j], ctx.MACCommands[j+1:]...)
+					for i := len(ctx.MACCommands) - 1; i != 0; i-- {
+						if ctx.MACCommands[i].CID == conflictingCID {
+							ctx.MACCommands = append(ctx.MACCommands[:i], ctx.MACCommands[i+1:]...)
 						}
 					}
 				}


### PR DESCRIPTION
In setMACCommands, the code checks to see whether the MAC payload contains any conflicting MAC commands and if so, removes the conflicting ones. However, the code was modifying the array while ascending through it in the for loop, which can cause bugs as the array range calculated at the beginning of the for loop is now wrong. This fix scans the array in descending order, thus avoiding any problems.

Fixes #323