### PR TITLE
Handle RXParamSetupReq/RXParamSetupAns Mac Command properly

### DIFF
--- a/internal/uplink/data/data.go
+++ b/internal/uplink/data/data.go
@@ -657,7 +657,7 @@ func handleUplinkMACCommands(ctx context.Context, ds *storage.DeviceSession, dp 
 
 	for _, cid := range cids {
 		switch cid {
-		case lorawan.RXTimingSetupAns:
+		case lorawan.RXTimingSetupAns, lorawan.RXParamSetupAns:
 			// From the specs:
 			// The RXTimingSetupAns command should be added in the FOpt field of all uplinks until a
 			// class A downlink is received by the end-device.


### PR DESCRIPTION
Handle **RXParamSetupReq/RXParamSetupAns** Mac Command properly as per the **[LoRaWAN™ 1.0.3 Specification](https://lora-alliance.org/sites/default/files/2018-07/lorawan1.0.3.pdf)**

Fixes #492 