### PR TITLE
Fix architecture and sponsors picture links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and the scheduling of downlink data transmissions.
 
 ## Architecture
 
-![architecture](https://www.chirpstack.ios/static/img/graphs/architecture.dot.png)
+![architecture](https://www.chirpstack.io/static/img/graphs/architecture.dot.png)
 
 ### Component links
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ and the scheduling of downlink data transmissions.
 
 ## Sponsors
 
-[![CableLabs](https://www.chirpstack.io/img/sponsors/cablelabs.png)](https://www.cablelabs.com/)
-[![SIDNFonds](https://www.chirpstack.io/img/sponsors/sidn_fonds.png)](https://www.sidnfonds.nl/)
-[![acklio](https://www.chirpstack.io/img/sponsors/acklio.png)](http://www.ackl.io/)
+[![CableLabs](https://www.chirpstack.io/static/img/sponsors/cablelabs.png)](https://www.cablelabs.com/)
+[![SIDNFonds](https://www.chirpstack.io/static/img/sponsors/sidn_fonds.png)](https://www.sidnfonds.nl/)
+[![acklio](https://www.chirpstack.io/static/img/sponsors/acklio.png)](http://www.ackl.io/)
 
 ## License
 


### PR DESCRIPTION
Hello,
there is a typo in the link to the architecture picture in the readme. The links to the sponsor pictures also seem to be broken.
I hope it is alright to create a PR for this.