### PR TITLE
add metrics for common errors

### DIFF
--- a/internal/api/client/asclient/pool.go
+++ b/internal/api/client/asclient/pool.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -89,11 +90,13 @@ func (p *pool) createClient(hostname string, caCert, tlsCert, tlsKey []byte) (*g
 
 	asOpts := []grpc.DialOption{
 		grpc.WithBlock(),
-		grpc.WithUnaryInterceptor(
+		grpc.WithChainUnaryInterceptor(
 			logging.UnaryClientCtxIDInterceptor,
+			grpc_prometheus.UnaryClientInterceptor,
 		),
-		grpc.WithStreamInterceptor(
+		grpc.WithChainStreamInterceptor(
 			grpc_logrus.StreamClientInterceptor(logrusEntry, logrusOpts...),
+			grpc_prometheus.StreamClientInterceptor,
 		),
 		grpc.WithBalancerName(roundrobin.Name),
 	}

--- a/internal/gateway/metrics.go
+++ b/internal/gateway/metrics.go
@@ -1,0 +1,29 @@
+package gateway
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	gatewayID = "gateway_id"
+)
+
+var (
+	ug = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "uplink_unknown_gateway_count",
+		Help: "The number of uplinks from unknown gateways (per gateway).",
+	}, []string{gatewayID})
+	gg = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "get_gateway_failed_count",
+		Help: "The number of gateway lookups that failed on uplink (per gateway).",
+	}, []string{gatewayID})
+)
+
+func uplinkUnknownGateway(g string) prometheus.Counter {
+	return ug.With(prometheus.Labels{gatewayID: g})
+}
+
+func getGatewayFailed(g string) prometheus.Counter {
+	return gg.With(prometheus.Labels{gatewayID: g})
+}

--- a/internal/gateway/rx_info.go
+++ b/internal/gateway/rx_info.go
@@ -35,11 +35,13 @@ func UpdateMetaDataInRxInfoSet(ctx context.Context, db sqlx.Queryer, rxInfoSet [
 		g, err := storage.GetAndCacheGateway(ctx, db, id)
 		if err != nil {
 			if errors.Cause(err) == storage.ErrDoesNotExist {
+				uplinkUnknownGateway(id.String()).Inc()
 				log.WithFields(log.Fields{
 					"ctx_id":     ctx.Value(logging.ContextIDKey),
 					"gateway_id": id,
 				}).Warning("uplink received by unknown gateway")
 			} else {
+				getGatewayFailed(id.String()).Inc()
 				log.WithFields(log.Fields{
 					"ctx_id":     ctx.Value(logging.ContextIDKey),
 					"gateway_id": id,

--- a/internal/gateway/stats/metrics.go
+++ b/internal/gateway/stats/metrics.go
@@ -1,0 +1,21 @@
+package stats
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	gatewayID = "gateway_id"
+)
+
+var (
+	ug = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "stats_unknown_gateway_count",
+		Help: "The number of uplinks from unknown gateways (per gateway).",
+	}, []string{gatewayID})
+)
+
+func statsUnknownGateway(g string) prometheus.Counter {
+	return ug.With(prometheus.Labels{gatewayID: g})
+}

--- a/internal/gateway/stats/stats.go
+++ b/internal/gateway/stats/stats.go
@@ -58,6 +58,7 @@ func getGateway(ctx *statsContext) error {
 	gw, err := storage.GetAndCacheGateway(ctx.ctx, storage.DB(), gatewayID)
 	if err != nil {
 		if errors.Cause(err) == storage.ErrDoesNotExist {
+			statsUnknownGateway(gatewayID.String()).Inc()
 			log.WithFields(log.Fields{
 				"ctx_id":     ctx.ctx.Value(logging.ContextIDKey),
 				"gateway_id": gatewayID,

--- a/internal/uplink/join/join.go
+++ b/internal/uplink/join/join.go
@@ -157,7 +157,8 @@ func (ctx *joinContext) getDeviceOrTryRoaming() error {
 
 			return ErrAbort
 		}
-		return errors.Wrap(err, "get device error")
+		getDeviceNotExist(ctx.JoinRequestPayload.DevEUI.String()).Inc()
+		return errors.Wrap(err, "get device error: deveui "+ctx.JoinRequestPayload.DevEUI.String())
 	}
 	return nil
 }
@@ -223,7 +224,7 @@ func (ctx *joinContext) validateNonce() error {
 				}).Error("uplink/join: as.HandleError error")
 			}
 		}
-
+		validateDevNonce(ctx.JoinRequestPayload.DevEUI.String()).Inc()
 		return returnErr
 	}
 

--- a/internal/uplink/join/metrics.go
+++ b/internal/uplink/join/metrics.go
@@ -1,0 +1,25 @@
+package join
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	gd = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "join_object_not_found_count",
+		Help: "The number of join requests where the device was not found (per deveui).",
+	}, []string{"deveui"})
+	dn = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "validate_dev_nonce_error_count",
+		Help: "The number of join requests where the dev nonce validation errored (per deveui).",
+	}, []string{"deveui"})
+)
+
+func getDeviceNotExist(d string) prometheus.Counter {
+	return gd.With(prometheus.Labels{"deveui": d})
+}
+
+func validateDevNonce(d string) prometheus.Counter {
+	return dn.With(prometheus.Labels{"deveui": d})
+}

--- a/internal/uplink/metrics.go
+++ b/internal/uplink/metrics.go
@@ -10,8 +10,16 @@ var (
 		Name: "uplink_counter",
 		Help: "The number of handled uplink frames by the Server (per message type).",
 	}, []string{"mType"})
+	ufce = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "uplink_frame_error_count",
+		Help: "The number of uplink frames that failed to be processed .",
+	})
 )
 
 func uplinkFrameCounter(e string) prometheus.Counter {
 	return uc.With(prometheus.Labels{"mType": e})
+}
+
+func uplinkFrameErrorCount() prometheus.Counter {
+	return ufce
 }

--- a/internal/uplink/uplink.go
+++ b/internal/uplink/uplink.go
@@ -111,6 +111,7 @@ func HandleUplinkFrames(wg *sync.WaitGroup) {
 			ctx = context.WithValue(ctx, logging.ContextIDKey, ctxID)
 
 			if err := HandleUplinkFrame(ctx, uplinkFrame); err != nil {
+				uplinkFrameErrorCount().Inc()
 				log.WithFields(log.Fields{
 					"ctx_id": ctxID,
 				}).WithError(err).Error("uplink: processing uplink frame error")


### PR DESCRIPTION
- adds the go-grpc-prometheus client prometheus interceptors
- adds metrics for errors i commonly see in the logs