### PR TITLE
don't run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ FROM alpine:3.11.2 AS production
 
 RUN apk --no-cache add ca-certificates tzdata
 COPY --from=development /chirpstack-network-server/build/chirpstack-network-server /usr/bin/chirpstack-network-server
+USER nobody:nogroup
 ENTRYPOINT ["/usr/bin/chirpstack-network-server"]


### PR DESCRIPTION
It's a good practice to avoid running docker containers with root access

I currently have the app server deployed with a wrapping docker container performing the same

```dockerfile
FROM chirpstack/chirpstack-network-server:3.11.0
USER nobody:nogroup
ENTRYPOINT ["/usr/bin/chirpstack-network-server"]
```