### PR TITLE
re-send AppSessionKey to ApplicationServer in case of connection issue

### DIFF
--- a/internal/uplink/data/data.go
+++ b/internal/uplink/data/data.go
@@ -521,8 +521,6 @@ func sendFRMPayloadToApplicationServer(ctx *dataContext) error {
 				AesKey:   ctx.DeviceSession.AppSKeyEvelope.AESKey,
 			},
 		}
-
-		ctx.DeviceSession.AppSKeyEvelope = nil
 	}
 
 	if ctx.ServiceProfile.AddGWMetadata {
@@ -552,6 +550,8 @@ func sendFRMPayloadToApplicationServer(ctx *dataContext) error {
 			}).WithError(err).Error("publish uplink data to application-server error")
 		}
 	}(ctx.ctx, ctx.ApplicationServerClient, publishDataUpReq)
+
+	ctx.DeviceSession.AppSKeyEvelope = nil
 
 	return nil
 }


### PR DESCRIPTION
If the network server creates a new AppSKeyEvelope for a DeviceSession (e.g. after a re-join), this information has to be sent as DeviceActivationContext to the ApplicationServer, in order to enable proper data decryption.

If this cal (NS->ASl fails, the DeviceActivationContext has to be re-sent with the next call.
This did not happen until now, as the AppSKeyEvelope is cleared before the actual call is executed.