### PR TITLE
Correctly compute ConfFCnt for confirmed uplink's downlink MIC

### DIFF
--- a/internal/downlink/data/data.go
+++ b/internal/downlink/data/data.go
@@ -1391,7 +1391,9 @@ func setPHYPayloads(ctx *dataContext) error {
 		}
 
 		// Set MIC.
-		if err := phy.SetDownlinkDataMIC(ctx.DeviceSession.GetMACVersion(), ctx.DeviceSession.FCntUp, ctx.DeviceSession.SNwkSIntKey); err != nil {
+		// If this is an ACK, then FCntUp has already been incremented by one. If
+		// this is not an ACK, then DownlinkDataMIC will zero out ConfFCnt.
+		if err := phy.SetDownlinkDataMIC(ctx.DeviceSession.GetMACVersion(), ctx.DeviceSession.FCntUp - 1, ctx.DeviceSession.SNwkSIntKey); err != nil {
 			return errors.Wrap(err, "set MIC error")
 		}
 


### PR DESCRIPTION
Currently, `ConfFCnt` in the MIC is always one larger than the `FCnt` of the corresponding uplink, as described in #539. This is because `ctx.DeviceSession.FCntUp` was already incremented by the initial processing of the uplink [here](https://github.com/brocaar/chirpstack-network-server/blob/4b18f02316b5a9990847e17cc320fb69ce3fc589/internal/uplink/data/data.go#L60).

I can confirm this PR enables a LoRaWAN v1.1 device to successfully complete ADR.

I did not add a test because I am still trying to understand the framework--this is my first time working with go. I don't see an existing test for v1.1 confirmed uplinks to base it off.

Fixes #539