### PR TITLE
Handle fNS XmitDataAns as a TxAck

### DIFF
--- a/internal/downlink/ack/ack_roaming_hns.go
+++ b/internal/downlink/ack/ack_roaming_hns.go
@@ -1,0 +1,40 @@
+package ack
+
+import (
+	"context"
+	"github.com/brocaar/chirpstack-api/go/v3/gw"
+	"github.com/brocaar/chirpstack-network-server/v3/internal/storage"
+	"github.com/brocaar/lorawan"
+	"github.com/brocaar/lorawan/backend"
+)
+
+type RoamingAckPayload struct {
+	XmitDataAns         backend.XmitDataAnsPayload
+	Token               uint32
+	DownlinkTXAck       *gw.DownlinkTXAck
+	DownlinkTXAckStatus gw.TxAckStatus
+	DownlinkFrame       *storage.DownlinkFrame
+	DeviceSession       storage.DeviceSession
+	DeviceProfile       storage.DeviceProfile
+	DeviceQueueItem     storage.DeviceQueueItem
+	MHDR                lorawan.MHDR
+	MACPayload          *lorawan.MACPayload
+}
+
+// HandleDownlinkXmitDataAns handles an ack as hNS.
+func HandleDownlinkXmitDataAns(ctx context.Context, pl RoamingAckPayload) error {
+	actx := ackContext{
+		ctx:                 ctx,
+		DB:                  storage.DB(),
+		DownlinkTXAck:       pl.DownlinkTXAck,
+		DownlinkTXAckStatus: pl.DownlinkTXAckStatus,
+	}
+
+	for _, t := range handleDownlinkTXAckTasks {
+		if err := t(&actx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
I made this change to fix issue #555 but I can see now that you did some additional changes to the code and removed the async XmitDataReq.

If you have time to look at this solution, it treats the XmitDataAns as an TxAck and fires that flow. If this is not done, frame-counters are never updated and subsequent downlinks will not be accepted by the end node. I made this async so that the downlink session is saved before TxAck handling is started, similar to how it is handled in fNS.