### PR TITLE
Log fNS downlink frames for gateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,4 @@ serve: build
 	./build/chirpstack-network-server
 
 run-compose-test:
-	docker-compose run --rm networkserver make test
+	docker-compose run --rm chirpstack-network-server make test

--- a/internal/downlink/ack/ack.go
+++ b/internal/downlink/ack/ack.go
@@ -229,7 +229,7 @@ func forConfirmedDownlink(funcs ...func(*ackContext) error) func(*ackContext) er
 func forMACOnlyPayload(funcs ...func(*ackContext) error) func(*ackContext) error {
 	return func(ctx *ackContext) error {
 		// for mac-only payload, the FPort must be nil or it must be set to 0.
-		if ctx.MACPayload == nil || !(ctx.MACPayload.FPort == nil || *ctx.MACPayload.FPort == 0) {
+		if len(ctx.DownlinkFrame.DevEui) == 0 || ctx.MACPayload == nil || !(ctx.MACPayload.FPort == nil || *ctx.MACPayload.FPort == 0) {
 			return nil
 		}
 


### PR DESCRIPTION
Save downlink frame when acting as fNS, this enables the frame logging for gateway functionality in tx ack flow.