### PR TITLE
Return `UnknownDevAddr` and `MICFailed` errors in roaming

### DIFF
--- a/internal/api/roaming/roaming.go
+++ b/internal/api/roaming/roaming.go
@@ -589,5 +589,14 @@ func (a *API) getBasePayloadResult(basePLReq backend.BasePayload, resCode backen
 }
 
 func (a *API) errToResultCode(err error) backend.ResultCode {
-	return backend.Other
+	switch {
+	case errors.Is(err, storage.ErrDoesNotExist):
+		return backend.UnknownDevAddr
+	case errors.Is(err, storage.ErrFrameCounterReset),
+		errors.Is(err, storage.ErrFrameCounterRetransmission),
+		errors.Is(err, storage.ErrInvalidMIC):
+		return backend.MICFailed
+	default:
+		return backend.Other
+	}
 }


### PR DESCRIPTION
Currently, all errors leading to uplink messages not being handled by ChirpStack result in `Other` result codes via Backend Interfaces. That isn't very useful for fNS to figure out why ChirpStack didn't accept the frame. This PR adds two common errors, `UnknownDevAddr` and `MICFailed`, to help with that.

We believe that a frame counter reset or a frame counter retransmission are MIC failures (without having a more accurate error code in BI to describe this). ChirpStack's error codes indicate that the FCnt based on the frame's 16 LSB is lower than permitted, but it can also mean that the rolled over FCnt is too high, which would indeed be a MIC mismatch. Generally speaking, protection against replays is about message integrity so this should all be `MICFailed`.