### PR TITLE
Add ignore_frequency_for_deduplication setting as a stopgap 

### DIFF
--- a/cmd/chirpstack-network-server/cmd/configfile.go
+++ b/cmd/chirpstack-network-server/cmd/configfile.go
@@ -150,6 +150,12 @@ net_id="{{ .NetworkServer.NetID }}"
 # unable to respond to the device within its receive-window.
 deduplication_delay="{{ .NetworkServer.DeduplicationDelay }}"
 
+# For packet de-duplication, ignore what frequency the packet came in on
+# 
+# This is a work around. And a security issue:
+# https://github.com/brocaar/chirpstack-network-server/issues/557#issuecomment-968719234 
+ignore_frequency_for_deduplication="{{ .NetworkServer.IgnoreFrequencyForDeduplication }}"
+
 # Device session expiration.
 #
 # The TTL value defines the time after which a device-session expires

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,11 +39,12 @@ type Config struct {
 	} `mapstructure:"redis"`
 
 	NetworkServer struct {
-		NetID                lorawan.NetID
-		NetIDString          string        `mapstructure:"net_id"`
-		DeduplicationDelay   time.Duration `mapstructure:"deduplication_delay"`
-		DeviceSessionTTL     time.Duration `mapstructure:"device_session_ttl"`
-		GetDownlinkDataDelay time.Duration `mapstructure:"get_downlink_data_delay"`
+		NetID                           lorawan.NetID
+		NetIDString                     string        `mapstructure:"net_id"`
+		DeduplicationDelay              time.Duration `mapstructure:"deduplication_delay"`
+		IgnoreFrequencyForDeduplication bool          `mapstructure:"ignore_frequency_for_deduplication"`
+		DeviceSessionTTL                time.Duration `mapstructure:"device_session_ttl"`
+		GetDownlinkDataDelay            time.Duration `mapstructure:"get_downlink_data_delay"`
 
 		Band struct {
 			Name                   band.Name `mapstructure:"name"`


### PR DESCRIPTION
For current data loss being experienced by us.

It defaults to false. If set to true, it will ignore the frequency on which the packets come in from the gateways. This allows a ghost packet to be gracefully collected as Just Another Packet to de-duplicate with.

Without this setting a ghost package gets in and overrides an established `dev_addr`. Leading to data being lost until the next JOIN request, with the edge device unaware that it has lost its JOIN status.

We have not been able to trace where the ghost JOINs come from. This stops those from being a problem for now.

- https://github.com/brocaar/chirpstack-network-server/issues/557#issuecomment-968719234 is not what we are experiencing, our devices are far apart
- This fixes https://github.com/brocaar/chirpstack-network-server/issues/566 for us