### PR TITLE
Add db to joinContext

### DIFF
--- a/internal/uplink/join/join_roaming_sns.go
+++ b/internal/uplink/join/join_roaming_sns.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/brocaar/chirpstack-network-server/v3/internal/models"
+	"github.com/brocaar/chirpstack-network-server/v3/internal/storage"
 	"github.com/brocaar/lorawan/backend"
 )
 
@@ -14,6 +15,7 @@ import (
 func HandleStartPRHNS(ctx context.Context, prStartPL backend.PRStartReqPayload, rxPacket models.RXPacket) (backend.PRStartAnsPayload, error) {
 	jctx := joinContext{
 		ctx:               ctx,
+		tx:                storage.DB(),
 		RXPacket:          rxPacket,
 		PRStartReqPayload: &prStartPL,
 	}


### PR DESCRIPTION
Some of the functions for passive roaming join need to be able to query devices, the first on that fails is `jctx.getDeviceOrTryRoaming`.

```
time="2022-07-21T21:08:16.008833995Z" level=info msg="Querying device" db="<nil>" dev_eui="[...]" for_udpate=true
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xa3e3b2]
```

```
goroutine 188 [running]:
github.com/jmoiron/sqlx.Get({0x0, 0x0}, {0xf3aee0, 0xc0004606c0}, {0xc000836200, 0x0}, {0xc000488690, 0x0, 0x0})
     /go/pkg/mod/github.com/jmoiron/sqlx@v1.2.0/sqlx.go:685 +0x32
github.com/brocaar/chirpstack-network-server/v3/internal/storage.GetDevice({0x2, 0x2}, {0x0, 0x0}, {0xaa, 0x49, 0xb5, 0x28, 0x68, 0x49, ...}, ...)
     /chirpstack-network-server/internal/storage/device.go:110 +0x345
github.com/brocaar/chirpstack-network-server/v3/internal/uplink/join.(*joinContext).getDeviceOrTryRoaming(0xc000128700)
     /chirpstack-network-server/internal/uplink/join/join.go:156 +0xb5
github.com/brocaar/chirpstack-network-server/v3/internal/uplink/join.HandleStartPRHNS({_, _}, {{{0xc0004876d8, 0x3}, {0xc0004876f8, 0x8}, {0xc0004876f0, 0x8}, 0x2a936a5c, {0xc0004876e0, ...}, ...}, ...}, ...)
     /chirpstack-network-server/internal/uplink/join/join_roaming_sns.go:40 +0x478
github.com/brocaar/chirpstack-network-server/v3/internal/api/roaming.(*API).handlePRStartReqJoin(_, {_, _}, {{0xc0001391aa, 0x3}, {0xc0001391b8, 0x8}, {0xc0001391b0, 0x8}, 0x2a936a5c, ...}, ...)
     /chirpstack-network-server/internal/api/roaming/roaming.go:479 +0x1cb
github.com/brocaar/chirpstack-network-server/v3/internal/api/roaming.(*API).handlePRStartReq(0xc000043fcc, {0x12ed5f0, 0xc0002fcc60}, {{0xc0001391aa, 0x3}, {0xc0001391b8, 0x8}, {0xc0001391b0, 0x8}, 0x2a936a5c, ...}, ...)
     /chirpstack-network-server/internal/api/roaming/roaming.go:376 +0x374
github.com/brocaar/chirpstack-network-server/v3/internal/api/roaming.(*API).handleRequest(0x0, {0x12ed5f0, 0xc0002fcc60}, {0x130c340, 0xc00022ab00}, {{0xc0001391aa, 0x3}, {0xc0001391b8, 0x8}, {0xc0001391b0, ...}, ...}, ...)
     /chirpstack-network-server/internal/api/roaming/roaming.go:320 +0x408
github.com/brocaar/chirpstack-network-server/v3/internal/api/roaming.(*API).handleAsync(0xc000043fcc, {0x12ed5f0, 0xc0002fcc60}, {0x130c340, 0xc00022ab00}, {{0xc0001391aa, 0x3}, {0xc0001391b8, 0x8}, {0xc0001391b0, ...}, ...}, ...)
     /chirpstack-network-server/internal/api/roaming/roaming.go:240 +0x9e
created by github.com/brocaar/chirpstack-network-server/v3/internal/api/roaming.(*API).ServeHTTP
     /chirpstack-network-server/internal/api/roaming/roaming.go:233 +0x19d6```