### PR TITLE
send ack errors from mac only messages to app server

### DIFF
--- a/internal/downlink/ack/ack.go
+++ b/internal/downlink/ack/ack.go
@@ -37,6 +37,9 @@ var handleDownlinkTXAckTasks = []func(*ackContext) error{
 		forApplicationPayload(
 			sendErrorToApplicationServerOnLastFrame,
 		),
+		forMACOnlyPayload(
+			sendErrorToApplicationServerOnLastFrame,
+		),
 		forMulticastPayload(
 			// TODO: For now we delete the multicast queue-item. What would be the best
 			// way to retry? Multicast is a bit more complicated as the downlinks are
@@ -498,8 +501,7 @@ func sendTxAckToApplicationServer(ctx *ackContext) error {
 
 func sendErrorToApplicationServerOnLastFrame(ctx *ackContext) error {
 	// Only send an error to the AS on the last possible attempt.
-	// We only want to send error for application payloads.
-	if (len(ctx.DownlinkTXAck.Items) == 0 && len(ctx.DownlinkFrame.DownlinkFrame.Items) >= 2) || ctx.MACPayload == nil || ctx.MACPayload.FPort == nil || *ctx.MACPayload.FPort == 0 {
+	if (len(ctx.DownlinkTXAck.Items) == 0 && len(ctx.DownlinkFrame.DownlinkFrame.Items) >= 2) || ctx.MACPayload == nil {
 		return nil
 	}
 

--- a/internal/testsuite/downlink_tx_ack_test.go
+++ b/internal/testsuite/downlink_tx_ack_test.go
@@ -371,7 +371,11 @@ func (ts *DownlinkTXAckTestSuite) TestDownlinkTXAck() {
 				},
 				Assert: []Assertion{
 					AssertNFCntDown(10),
-					AssertASNoHandleErrorRequest(), // no error as this is mac-layer only
+					AssertASHandleErrorRequest(as.HandleErrorRequest{
+						DevEui: ts.Device.DevEUI[:],
+						Type:   as.ErrorType_DATA_DOWN_GATEWAY,
+						Error:  "TX_FREQ",
+					}),
 					AssertASNoHandleTxAckRequest(),
 					AssertNCNoHandleDownlinkMetaDataRequest(),
 				},


### PR DESCRIPTION
try to add the missing feature that currently ack errors from mac only messages are ignored